### PR TITLE
handle empty case

### DIFF
--- a/src/JLFmt.jl
+++ b/src/JLFmt.jl
@@ -64,6 +64,9 @@ include("nest.jl")
 include("print.jl")
 
 function format(text::String; indent_width=4, max_width=80)
+    if isempty(text)
+        return text
+    end
     d = Document(text)
     s = State(d, indent_width, 0, 1, 0, max_width)
     x = CSTParser.parse(text, true)

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -22,6 +22,7 @@ end
 
 @testset "basic" begin
     @test format("a") == "a"
+    @test format("") == ""
 end
 
 @testset "tuples" begin
@@ -466,7 +467,7 @@ end
        begin
            \"""
                f
-    
+
            docstring for f
            :(function \$(dict[:name]){\$(all_params...)}(\$(dict[:args]...);
                                                 \$(dict[:kwargs]...))::\$rtype
@@ -502,11 +503,11 @@ end
 
     str = """
     \"""
-     \\\\ 
+     \\\\
     \"""
     x"""
     @test format("\" \\\\ \" x") == str
-    
+
     #= str = """ =#
     #= begin =#
     #=     s = \"\"\"This is a multiline string. =#


### PR DESCRIPTION
not sure where you want to check for empty, but here seems to be fine ;)
Without this i get:
```julia
BoundsError: attempt to access 1-element Array{UnitRange{Int64},1} at index [0]
getindex at array.jl:729 [inlined]
print_tree(::Base.GenericIOBuffer{Array{UInt8,1}}, ::JLFmt.NotCode, ::JLFmt.State) at print.jl:58
#format#37(::Int64, ::Int64, ::Function, ::String) at JLFmt.jl:82
format at JLFmt.jl:67 [inlined]
format_files(::String) at untitled-2a72259a4ef625cc5e5f6feec2d1ec15:86
(::getfield(Main, Symbol("##28#31")))(::String) at untitled-2a72259a4ef625cc5e5f6feec2d1ec15:81
foreach(::getfield(Main, Symbol("##28#31")), ::Array{String,1}) at abstractarray.jl:1866
format_files(::String) at untitled-2a72259a4ef625cc5e5f6feec2d1ec15:81
top-level scope at none:0
```
So maybe one should also boundcheck there ;) 